### PR TITLE
feat: add-controllers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.2</version>
+		<version>2.7.14</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/src/main/java/ru/practicum/shareit/booking/dto/BookingDto.java
+++ b/src/main/java/ru/practicum/shareit/booking/dto/BookingDto.java
@@ -1,7 +1,26 @@
 package ru.practicum.shareit.booking.dto;
 
-/**
- * TODO Sprint add-bookings.
- */
+import lombok.Data;
+import ru.practicum.shareit.item.dto.ItemDto;
+import ru.practicum.shareit.user.dto.UserDto;
+
+import java.time.LocalDateTime;
+
+@Data
 public class BookingDto {
+    private Long id;
+    private LocalDateTime start;
+    private LocalDateTime end;
+    private ItemDto item;
+    private UserDto booker;
+    private Status status;
+    private String request;
+
+    public enum Status {
+        WAITING,
+        APPROVED,
+        REJECTED,
+        CANCELED
+    }
+
 }

--- a/src/main/java/ru/practicum/shareit/exception/ErrorHandler.java
+++ b/src/main/java/ru/practicum/shareit/exception/ErrorHandler.java
@@ -1,0 +1,52 @@
+package ru.practicum.shareit.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.validation.ConstraintViolationException;
+
+@Slf4j
+@RestControllerAdvice
+public class ErrorHandler {
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponse handleIntersectionValuesException(final IntersectionValuesException e) {
+        log.error("ERROR Intersections conflict 409! {}", e.getMessage());
+        return new ErrorResponse("Ошибка пересечений: " + e.getMessage());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleNotFoundException(final NotFoundException e) {
+        log.error("ERROR Not Found 404! {}", e.getMessage());
+        return new ErrorResponse("Ошибка не найденного объекта: " + e.getMessage());
+    }
+
+    @ExceptionHandler({MethodArgumentNotValidException.class, ConstraintViolationException.class,})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleValidationException(final RuntimeException e) {
+        log.error("ERROR Validation 400! {}", e.getMessage());
+        return new ErrorResponse("Ошибка валидации: " + e.getMessage());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleMissingRequestHeaderException(final MissingRequestHeaderException e) {
+        log.error("ERROR Missing Request Header 400! {}", e.getMessage());
+        return new ErrorResponse("Пропущен заголовок: " + e.getMessage());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponse handleException(final Exception e) {
+        log.error("ERROR Unhandled Error conflict 500! {}", e.getClass());
+        return new ErrorResponse("Непредвиденная ошибка: " + e.getClass());
+    }
+
+}

--- a/src/main/java/ru/practicum/shareit/exception/ErrorResponse.java
+++ b/src/main/java/ru/practicum/shareit/exception/ErrorResponse.java
@@ -1,0 +1,14 @@
+package ru.practicum.shareit.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@ToString
+public class ErrorResponse {
+
+    @Getter
+    private final String error;
+
+}

--- a/src/main/java/ru/practicum/shareit/exception/IntersectionValuesException.java
+++ b/src/main/java/ru/practicum/shareit/exception/IntersectionValuesException.java
@@ -1,0 +1,8 @@
+package ru.practicum.shareit.exception;
+
+public class IntersectionValuesException extends RuntimeException {
+    public IntersectionValuesException(Object value) {
+        super("Founded intersection of value " + value);
+    }
+
+}

--- a/src/main/java/ru/practicum/shareit/exception/NotFoundException.java
+++ b/src/main/java/ru/practicum/shareit/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package ru.practicum.shareit.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(Object value) {
+        super("Not found searched object by value: " + value);
+    }
+}

--- a/src/main/java/ru/practicum/shareit/item/ItemController.java
+++ b/src/main/java/ru/practicum/shareit/item/ItemController.java
@@ -1,12 +1,58 @@
 package ru.practicum.shareit.item;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import ru.practicum.shareit.item.dto.ItemDto;
 
-/**
- * TODO Sprint add-controllers.
- */
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.Collection;
+
+import static ru.practicum.shareit.item.dto.ItemMapper.toItem;
+import static ru.practicum.shareit.item.dto.ItemMapper.toItemDto;
+
+@Slf4j
 @RestController
 @RequestMapping("/items")
+@RequiredArgsConstructor
 public class ItemController {
+
+    private final ItemService itemService;
+
+    @GetMapping("/{itemId}")
+    public ItemDto getItem(@PathVariable Long itemId) {
+        log.info("Called method getItem of class ItemController with args: itemId = {};", itemId);
+        return toItemDto(itemService.getItem(itemId));
+    }
+
+    @GetMapping
+    public Collection<ItemDto> getItems(@RequestHeader("X-Sharer-User-Id") @NotNull Long userId) {
+        log.info("Called method getItem of class ItemController with args: userId = {};", userId);
+        return toItemDto(itemService.getItems(userId));
+    }
+
+    @GetMapping("/search")
+    public Collection<ItemDto> searchItems(@RequestParam(value = "text", defaultValue = "") String value) {
+        log.info("Called method searchItems of class ItemController with args: value = {};", value);
+        return toItemDto(itemService.searchItems(value));
+    }
+
+    @PostMapping
+    public ItemDto addItem(@RequestBody @Valid ItemDto itemDto,
+                           @RequestHeader("X-Sharer-User-Id") @NotNull Long userId) {
+        log.info("Called method addItem of class ItemController with args: itemDto = {}; userId = {};", itemDto, userId);
+        itemDto.setOwnerId(userId);
+        return toItemDto(itemService.addItem(toItem(itemDto), userId));
+    }
+
+    @PatchMapping("/{itemId}")
+    public ItemDto updateItem(@RequestBody ItemDto itemDto,
+                              @PathVariable Long itemId,
+                              @RequestHeader("X-Sharer-User-Id") @NotNull Long userId) {
+        log.info("Called method updateItem of class ItemController with args: itemDto = {};", itemDto);
+        itemDto.setId(itemId);
+        return toItemDto(itemService.updateItem(toItem(itemDto), userId));
+    }
+
 }

--- a/src/main/java/ru/practicum/shareit/item/ItemRepository.java
+++ b/src/main/java/ru/practicum/shareit/item/ItemRepository.java
@@ -1,0 +1,81 @@
+package ru.practicum.shareit.item;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import ru.practicum.shareit.exception.NotFoundException;
+import ru.practicum.shareit.item.model.Item;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Repository
+public class ItemRepository {
+
+    private final Map<Long, Item> items = new HashMap<>();
+    private long sec = 0;
+
+    public Optional<Item> findById(long itemId) {
+        log.debug("Called method findById of class ItemRepository with args: itemId = {};", itemId);
+        return Optional.of(items.get(itemId));
+    }
+
+    public Collection<Item> getAll(long userId) {
+        log.debug("Called method getAll of class ItemRepository with args: userId = {};", userId);
+        return items.values().stream()
+                .filter(item -> item.getOwner().getId().equals(userId))
+                .collect(Collectors.toList());
+    }
+
+    public Optional<Item> save(Item item) {
+        log.debug("Called method save of class ItemRepository with args: item = {};", item);
+        item.setId(++sec);
+        items.put(item.getId(), item);
+        return Optional.of(item);
+    }
+
+    public Optional<Item> update(Item item) {
+        log.debug("Called method update of class ItemRepository with args: item = {};", item);
+        return Optional.of(updateItemFields(item));
+    }
+
+    public Collection<Item> searchByValue(String searchedValue) {
+        log.debug("Called method searchByValue of class ItemRepository with args: searchedValue = {};", searchedValue);
+        String lowerSearchedValue = searchedValue.toLowerCase();
+        return items.values().stream()
+                .filter(item -> item.getAvailable() && itemFieldsContainsValue(item, lowerSearchedValue))
+                .collect(Collectors.toList());
+    }
+
+    private Item updateItemFields(Item item) {
+        log.trace("Called method updateItemFields of class ItemService with args: item = {};", item);
+        Item itemUpdated = items.get(item.getId());
+
+        validateItemsByUser(itemUpdated, item);
+
+        if (item.getName() != null) {
+            itemUpdated.setName(item.getName());
+        }
+        if (item.getDescription() != null) {
+            itemUpdated.setDescription(item.getDescription());
+        }
+        if (item.getAvailable() != null) {
+            itemUpdated.setAvailable(item.getAvailable());
+        }
+
+        return itemUpdated;
+    }
+
+    private void validateItemsByUser(Item itemInternal, Item itemExternal) {
+        log.trace("Called method validateItemsByUser of class ItemService " +
+                "with args: itemInternal = {}; itemExternal = {};", itemInternal, itemExternal);
+        if (!itemInternal.getOwner().equals(itemExternal.getOwner())) {
+            throw new NotFoundException(itemExternal.getId());
+        }
+    }
+
+    private boolean itemFieldsContainsValue(Item item, String value) {
+        return item.getName().toLowerCase().contains(value) || item.getDescription().toLowerCase().contains(value);
+    }
+
+}

--- a/src/main/java/ru/practicum/shareit/item/ItemService.java
+++ b/src/main/java/ru/practicum/shareit/item/ItemService.java
@@ -1,0 +1,54 @@
+package ru.practicum.shareit.item;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import ru.practicum.shareit.exception.NotFoundException;
+import ru.practicum.shareit.item.model.Item;
+import ru.practicum.shareit.user.UserService;
+
+import java.util.Collection;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ItemService {
+
+    private final UserService userService;
+    private final ItemRepository itemRepository;
+
+    public Item getItem(long itemId) {
+        log.info("Called method getItem of class ItemService with args: itemId = {};", itemId);
+        return itemRepository.findById(itemId)
+                .orElseThrow(() -> new NotFoundException(itemId));
+    }
+
+    public Collection<Item> getItems(long ownerId) {
+        log.info("Called method getItems of class ItemService with args: ownerId = {};", ownerId);
+        return itemRepository.getAll(ownerId);
+    }
+
+    public Item addItem(Item item, long userId) {
+        log.info("Called method addItem of class ItemService with args: item = {};", item);
+        item.setOwner(userService.getUser(userId));
+        return itemRepository.save(item)
+                .orElseThrow(() -> new NotFoundException(item));
+    }
+
+    public Item updateItem(Item item, long userId) {
+        log.info("Called method updateItem of class ItemService with args: item = {}; userId = {};", item, userId);
+        item.setOwner(userService.getUser(userId));
+        return itemRepository.update(item)
+                .orElseThrow(() -> new NotFoundException(item));
+    }
+
+    public Collection<Item> searchItems(String searchedValue) {
+        log.info("Called method searchItem of class ItemService with args: searchedValue = {};", searchedValue);
+        if (searchedValue.isBlank()) {
+            return List.of();
+        }
+        return itemRepository.searchByValue(searchedValue);
+    }
+
+}

--- a/src/main/java/ru/practicum/shareit/item/dto/ItemDto.java
+++ b/src/main/java/ru/practicum/shareit/item/dto/ItemDto.java
@@ -1,7 +1,22 @@
 package ru.practicum.shareit.item.dto;
 
-/**
- * TODO Sprint add-controllers.
- */
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Data
+@Builder
 public class ItemDto {
+
+    private Long id;
+    @NotBlank
+    private String name;
+    @NotBlank
+    private String description;
+    @NotNull
+    private Boolean available;
+    private Long ownerId;
+
 }

--- a/src/main/java/ru/practicum/shareit/item/dto/ItemMapper.java
+++ b/src/main/java/ru/practicum/shareit/item/dto/ItemMapper.java
@@ -1,0 +1,43 @@
+package ru.practicum.shareit.item.dto;
+
+import lombok.extern.slf4j.Slf4j;
+import ru.practicum.shareit.item.model.Item;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class ItemMapper {
+
+    public static ItemDto toItemDto(Item item) {
+        log.trace("Called method toItemDto of class ItemMapper with args: item = {};", item);
+        return ItemDto.builder()
+                .id(item.getId())
+                .name(item.getName())
+                .description(item.getDescription())
+                .available(item.getAvailable())
+                .ownerId(item.getOwner().getId())
+                .build();
+    }
+
+    public static Collection<ItemDto> toItemDto(Collection<Item> items) {
+        log.trace("Called method toItemDto of class ItemMapper with args: items = {};", items);
+        return items.stream().map(ItemMapper::toItemDto).collect(Collectors.toList());
+    }
+
+    public static Item toItem(ItemDto itemDto) {
+        log.trace("Called method toItem of class ItemMapper with args: itemDto = {};", itemDto);
+        return Item.builder()
+                .id(itemDto.getId())
+                .name(itemDto.getName())
+                .description(itemDto.getDescription())
+                .available(itemDto.getAvailable())
+                .build();
+    }
+
+    public static Collection<Item> toItem(Collection<ItemDto> itemDtos) {
+        log.trace("Called method toItem of class ItemMapper with args: itemDtos = {};", itemDtos);
+        return itemDtos.stream().map(ItemMapper::toItem).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/ru/practicum/shareit/item/model/Item.java
+++ b/src/main/java/ru/practicum/shareit/item/model/Item.java
@@ -1,7 +1,19 @@
 package ru.practicum.shareit.item.model;
 
-/**
- * TODO Sprint add-controllers.
- */
+import lombok.Builder;
+import lombok.Data;
+import ru.practicum.shareit.request.ItemRequest;
+import ru.practicum.shareit.user.User;
+
+@Data
+@Builder
 public class Item {
+
+    private Long id;
+    private String name;
+    private String description;
+    private Boolean available;
+    private User owner;
+    private ItemRequest request;
+
 }

--- a/src/main/java/ru/practicum/shareit/request/ItemRequest.java
+++ b/src/main/java/ru/practicum/shareit/request/ItemRequest.java
@@ -1,7 +1,16 @@
 package ru.practicum.shareit.request;
 
-/**
- * TODO Sprint add-item-requests.
- */
+import lombok.Builder;
+import lombok.Data;
+import ru.practicum.shareit.user.User;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
 public class ItemRequest {
+    private Long id;
+    private String description;
+    private User requester;
+    private LocalDateTime created;
 }

--- a/src/main/java/ru/practicum/shareit/request/dto/ItemRequestDto.java
+++ b/src/main/java/ru/practicum/shareit/request/dto/ItemRequestDto.java
@@ -1,7 +1,16 @@
 package ru.practicum.shareit.request.dto;
 
-/**
- * TODO Sprint add-item-requests.
- */
+import lombok.Builder;
+import lombok.Data;
+import ru.practicum.shareit.user.dto.UserDto;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
 public class ItemRequestDto {
+    private Long id;
+    private String description;
+    private UserDto requester;
+    private LocalDateTime created;
 }

--- a/src/main/java/ru/practicum/shareit/request/dto/ItemRequestMapper.java
+++ b/src/main/java/ru/practicum/shareit/request/dto/ItemRequestMapper.java
@@ -1,0 +1,24 @@
+package ru.practicum.shareit.request.dto;
+
+import ru.practicum.shareit.request.ItemRequest;
+import ru.practicum.shareit.user.dto.UserMapper;
+
+public class ItemRequestMapper {
+    public static ItemRequestDto toUserDto(ItemRequest itemRequest) {
+        return ItemRequestDto.builder()
+                .id(itemRequest.getId())
+                .description(itemRequest.getDescription())
+                .requester(UserMapper.toUserDto(itemRequest.getRequester()))
+                .created(itemRequest.getCreated())
+                .build();
+    }
+
+    public static ItemRequest toUser(ItemRequestDto itemRequest) {
+        return ItemRequest.builder()
+                .id(itemRequest.getId())
+                .description(itemRequest.getDescription())
+                .requester(UserMapper.toUser(itemRequest.getRequester()))
+                .created(itemRequest.getCreated())
+                .build();
+    }
+}

--- a/src/main/java/ru/practicum/shareit/user/User.java
+++ b/src/main/java/ru/practicum/shareit/user/User.java
@@ -1,7 +1,12 @@
 package ru.practicum.shareit.user;
 
-/**
- * TODO Sprint add-controllers.
- */
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
 public class User {
+    private Long id;
+    private String name;
+    private String email;
 }

--- a/src/main/java/ru/practicum/shareit/user/UserController.java
+++ b/src/main/java/ru/practicum/shareit/user/UserController.java
@@ -1,12 +1,56 @@
 package ru.practicum.shareit.user;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import ru.practicum.shareit.user.dto.UserDto;
 
-/**
- * TODO Sprint add-controllers.
- */
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.Collection;
+
+import static ru.practicum.shareit.user.dto.UserMapper.toUser;
+import static ru.practicum.shareit.user.dto.UserMapper.toUserDto;
+
+@Slf4j
 @RestController
 @RequestMapping(path = "/users")
+@RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping
+    public Collection<UserDto> getUsers() {
+        log.info("Called method getUsers of class UserController with args: ");
+        return toUserDto(userService.getUsers());
+    }
+
+    @GetMapping("/{userId}")
+    public UserDto getUser(@PathVariable @NotNull Integer userId) {
+        log.info("Called method getUser of class UserController with args: userId = {};", userId);
+        return toUserDto(userService.getUser(userId));
+    }
+
+    @PostMapping
+    public UserDto addUser(@Valid @RequestBody UserDto userDto) {
+        log.info("Called method addUser of class UserController with args: userDto = {};", userDto);
+        return toUserDto(userService.addUser(toUser(userDto)));
+    }
+
+    @PatchMapping("/{userId}")
+    public UserDto updateUser(@PathVariable @NotNull Integer userId,
+                              @RequestBody UserDto userDto) {
+        log.info("Called method updateUser of class UserController " +
+                "with args: userId = {}; userDto = {};", userId, userDto);
+        return toUserDto(userService.updateUser(toUser(userDto), userId));
+    }
+
+    @DeleteMapping("/{userId}")
+    public UserDto deleteUser(@PathVariable @NotNull Integer userId) {
+        log.info("Called method deleteUser of class UserController with args: userId = {};", userId);
+        return toUserDto(userService.deleteUser(userId));
+    }
+
 }
+

--- a/src/main/java/ru/practicum/shareit/user/UserRepository.java
+++ b/src/main/java/ru/practicum/shareit/user/UserRepository.java
@@ -1,0 +1,82 @@
+package ru.practicum.shareit.user;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import ru.practicum.shareit.exception.IntersectionValuesException;
+import ru.practicum.shareit.exception.NotFoundException;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Repository
+public class UserRepository {
+
+    private final Map<Long, User> users = new HashMap<>();
+
+    private long sec = 0;
+
+    public Optional<User> findById(long userId) {
+        log.debug("Called method getAll of class UserRepository with args: userId = {};", userId);
+        User user = users.get(userId);
+        if (user == null) {
+            throw new NotFoundException(userId);
+        }
+        return Optional.of(user);
+    }
+
+    public Collection<User> getAll() {
+        log.debug("Called method getAll of class UserRepository with args: ;");
+        return users.values();
+    }
+
+    public Optional<User> save(User user) {
+        log.debug("Called method save of class UserRepository with args: user = {};", user);
+        user.setId(sec + 1);
+        User userTemp = putUser(user);
+        sec++;
+        return Optional.of(userTemp);
+    }
+
+    public Optional<User> update(User user) {
+        log.debug("Called method update of class UserService with args: user = {};", user);
+        return Optional.of(updateUserFields(user));
+    }
+
+
+    public Optional<User> delete(long userId) {
+        log.debug("Called method delete of class UserRepository with args: userId = {};", userId);
+        return Optional.of(users.remove(userId));
+    }
+
+    private User putUser(User user) {
+        log.debug("Called method putUser of class UserRepository with args: user = {};", user);
+        validateUser(user);
+        users.put(user.getId(), user);
+        return users.get(user.getId());
+    }
+
+    private User updateUserFields(User user) {
+        log.trace("Called method updateUserFields of class UserRepository with args: user = {};", user);
+        User userUpdated = users.get(user.getId());
+        if (user.getEmail() != null) {
+            validateUser(user);
+            userUpdated.setEmail(user.getEmail());
+        }
+        if (user.getName() != null) {
+            userUpdated.setName(user.getName());
+        }
+        return userUpdated;
+    }
+
+    private void validateUser(User user) {
+        log.trace("Called method validateUser of class UserRepository with args: user = {}", user);
+        if (users.values().stream()
+                .anyMatch(userTemp -> user.getEmail().equals(userTemp.getEmail())
+                        && !userTemp.getId().equals(user.getId()))) {
+            throw new IntersectionValuesException(user.getEmail());
+        }
+    }
+}

--- a/src/main/java/ru/practicum/shareit/user/UserService.java
+++ b/src/main/java/ru/practicum/shareit/user/UserService.java
@@ -1,0 +1,47 @@
+package ru.practicum.shareit.user;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import ru.practicum.shareit.exception.NotFoundException;
+
+import java.util.Collection;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User getUser(long userId) {
+        log.info("Called method getUser of class UserService with args: userId = {};", userId);
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(userId));
+    }
+
+    public Collection<User> getUsers() {
+        log.info("Called method getUsers of class UserService with args: ;");
+        return userRepository.getAll();
+    }
+
+    public User addUser(User user) {
+        log.info("Called method addUser of class UserService with args: user = {};", user);
+        return userRepository.save(user)
+                .orElseThrow(() -> new NotFoundException(user));
+    }
+
+    public User updateUser(User user, long userId) {
+        log.info("Called method updateUser of class UserService with args: userId = {}, user = {};", userId, user);
+        user.setId(userId);
+        return userRepository.update(user)
+                .orElseThrow(() -> new NotFoundException(userId));
+    }
+
+    public User deleteUser(long userId) {
+        log.info("Called method deleteUser of class UserService with args: userId = {};", userId);
+        return userRepository.delete(userId)
+                .orElseThrow(() -> new NotFoundException(userId));
+    }
+
+}

--- a/src/main/java/ru/practicum/shareit/user/dto/UserDto.java
+++ b/src/main/java/ru/practicum/shareit/user/dto/UserDto.java
@@ -1,0 +1,20 @@
+package ru.practicum.shareit.user.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+@Data
+@Builder
+public class UserDto {
+
+    private Long id;
+    @NotBlank
+    private String name;
+    @Email
+    @NotBlank
+    private String email;
+
+}

--- a/src/main/java/ru/practicum/shareit/user/dto/UserMapper.java
+++ b/src/main/java/ru/practicum/shareit/user/dto/UserMapper.java
@@ -1,0 +1,40 @@
+package ru.practicum.shareit.user.dto;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import ru.practicum.shareit.user.User;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class UserMapper {
+    public static UserDto toUserDto(User user) {
+        log.trace("Called method toUserDto of class UserMapper with args: user = {};", user);
+        return UserDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .build();
+    }
+
+    public static Collection<UserDto> toUserDto(Collection<User> userDtos) {
+        log.trace("Called method toUserDto of class UserMapper with args: userDtos = {};", userDtos);
+        return userDtos.stream().map(UserMapper::toUserDto).collect(Collectors.toList());
+    }
+
+    public static User toUser(UserDto userDto) {
+        log.trace("Called method toUser of class UserMapper with args: userDto = {};", userDto);
+        return User.builder()
+                .id(userDto.getId())
+                .email(userDto.getEmail())
+                .name(userDto.getName())
+                .build();
+    }
+
+    public static Collection<User> toUser(Collection<UserDto> users) {
+        log.trace("Called method toUser of class UserMapper with args: users = {};", users);
+        return users.stream().map(UserMapper::toUser).collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,7 @@ logging.level.org.springframework.orm.jpa=INFO
 logging.level.org.springframework.transaction=INFO
 logging.level.org.springframework.transaction.interceptor=TRACE
 logging.level.org.springframework.orm.jpa.JpaTransactionManager=DEBUG
+logging.level.ru.practicum.shareit.user.UserService=TRACE
 
 #---
 # TODO Append connection to DB


### PR DESCRIPTION
Добавление контроллеров и сервисов для обработки запросов по item и user. Хранение реализовано через HashMap в памяти, чтобы простые запросы на get происходили с высокой скоростью. 
Проблема того, что один сервис использует другой, в связи с чем им (с моей точки зрения) необходимо возвращать полноценные модели данных, для контроллеров необходимо получать Dto модели, довольно насущная. Было 3 варианта:
1 Создать множество перегрузок для работы с одними методами внутри приложения (уровень сервисов) и другими для контроллером. Сразу же отказано по причине перегруженности классов.
2 Сервисы должны работать с полными моделями данных, а контроллеры будут их маппить через соответстующие классы. Данный метод не сильно приветствуются, потому что контроллеры проводят лишние операции по преобразованиям, однако ввиду простоты реализации на уровне сервисов остановился на данном варианте.
2.1 На плечи Mapper-классов полностью ложиться задача по преобразованию данных. То есть они используют сервисы для своей работы. Посчитал, что при масштабировании приложения и усложнении его логики могут появиться непредвиденные проблемы и придется всё равно вернуться к стандартному варианту 2, где на уровне сервисов находиться та самая логика, которая может вызвать ошибки
3 Мой личный фаворит, однако я не видел такого решения проблемы, поэтому отказался. Создать дополнительный слой DtoService'ов, которые будут использоваться контроллерами. Их основная задача - использование обычных сервисов для получения данных, их связывания (на примере Item и его поля owner, класс User), а также преобразования данных. Позволяет избавиться от сложных зависимостей Service-классов, разделив работы с поиском данных (пример searchItem с его "фильтрацией по имени и описанию") и их преобразованиями на разные уровни абстракции, слои приложения